### PR TITLE
fix: Bug 3, 4, 5 — IndexOf crash, silent rate-limit bypass, SanitizePromptInput double-escaping

### DIFF
--- a/AdaptiveVerificationEngine.cs
+++ b/AdaptiveVerificationEngine.cs
@@ -226,90 +226,85 @@ public sealed class AdaptiveVerificationEngine : IDisposable
     {
         var aggregator = new VoteAggregator();
 
-        // Security: Acquire rate limit permit before proceeding
-        // Fix (Bug 4): throw instead of silently continuing when rate limit is exceeded
+        // Security: Acquire rate limit permit before proceeding.
+        // Fix (Bug 4): throw instead of silently continuing when rate limit is exceeded.
+        // NOTE: Only the lease is disposed here — _rateLimiter is a class-level field
+        // and is only disposed in the IDisposable.Dispose() method below.
         using var lease = await _rateLimiter.AcquireAsync(1, ct);
         if (!lease.IsAcquired)
             throw new InvalidOperationException("Rate limit exceeded — too many concurrent requests. Please try again shortly.");
 
+        // Fix (Bug 3): build an indexed list of (model, task) pairs so we never
+        // rely on List<Task>.IndexOf(), which uses reference equality and can
+        // return -1 if the task object isn't found, causing an IndexOutOfRangeException.
+        var indexedTasks = CouncilModels
+            .Select((m, i) => (Model: m, Task: _client.VerifyAsync(m.Model, draft, query, m.Weight, CouncilTimeout, ct)))
+            .ToList();
+
+        var tasks = indexedTasks.Select(x => x.Task).ToList();
+
+        // Wait for all with overall timeout (give extra buffer beyond individual timeout)
         try
         {
-            // Fix (Bug 3): build an indexed list of (model, task) pairs so we never
-            // rely on List<Task>.IndexOf(), which uses reference equality and can
-            // return -1 if the task object isn't found, causing an IndexOutOfRangeException.
-            var indexedTasks = CouncilModels
-                .Select((m, i) => (Model: m, Task: _client.VerifyAsync(m.Model, draft, query, m.Weight, CouncilTimeout, ct)))
-                .ToList();
+            var overallTimeout = Task.Delay(CouncilTimeout + TimeSpan.FromSeconds(2), ct);
+            var allTasks = Task.WhenAll(tasks);
 
-            var tasks = indexedTasks.Select(x => x.Task).ToList();
+            var completed = await Task.WhenAny(allTasks, overallTimeout);
 
-            // Wait for all with overall timeout (give extra buffer beyond individual timeout)
-            try
+            if (completed == allTasks)
             {
-                var overallTimeout = Task.Delay(CouncilTimeout + TimeSpan.FromSeconds(2), ct);
-                var allTasks = Task.WhenAll(tasks);
-
-                var completed = await Task.WhenAny(allTasks, overallTimeout);
-
-                if (completed == allTasks)
+                // All completed within timeout
+                foreach (var vote in await allTasks)
                 {
-                    // All completed within timeout
-                    foreach (var vote in await allTasks)
+                    aggregator.Add(vote);
+                    onStatus?.Invoke($"  {vote.ModelName}: {(vote.TimedOut ? "TIMEOUT" : vote.Error ?? (vote.Result.Valid ? "✓ VALID" : "✗ INVALID"))} ({vote.ResponseTime.TotalSeconds:F1}s)");
+                }
+            }
+            else
+            {
+                // Overall timeout hit — collect whatever finished
+                onStatus?.Invoke("Council overall timeout — collecting partial results...");
+                foreach (var (modelInfo, task) in indexedTasks)
+                {
+                    if (task.IsCompletedSuccessfully)
                     {
+                        var vote = await task;
                         aggregator.Add(vote);
-                        onStatus?.Invoke($"  {vote.ModelName}: {(vote.TimedOut ? "TIMEOUT" : vote.Error ?? (vote.Result.Valid ? "✓ VALID" : "✗ INVALID"))} ({vote.ResponseTime.TotalSeconds:F1}s)");
+                        onStatus?.Invoke($"  {vote.ModelName}: {(vote.Result.Valid ? "✓" : "✗")} ({vote.ResponseTime.TotalSeconds:F1}s)");
                     }
-                }
-                else
-                {
-                    // Overall timeout hit — collect whatever finished
-                    onStatus?.Invoke("Council overall timeout — collecting partial results...");
-                    foreach (var (modelInfo, task) in indexedTasks)
+                    else
                     {
-                        if (task.IsCompletedSuccessfully)
-                        {
-                            var vote = await task;
-                            aggregator.Add(vote);
-                            onStatus?.Invoke($"  {vote.ModelName}: {(vote.Result.Valid ? "✓" : "✗")} ({vote.ResponseTime.TotalSeconds:F1}s)");
-                        }
-                        else
-                        {
-                            // Create a timeout vote for tasks that didn't finish
-                            // Safe: modelInfo is already associated with this task — no IndexOf needed
-                            aggregator.Add(new CouncilVote(
-                                modelInfo.Model, modelInfo.Weight,
-                                new VerificationResult(),
-                                CouncilTimeout, TimedOut: true));
-                        }
+                        // Create a timeout vote for tasks that didn't finish.
+                        // Safe: modelInfo is already associated with this task — no IndexOf needed.
+                        aggregator.Add(new CouncilVote(
+                            modelInfo.Model, modelInfo.Weight,
+                            new VerificationResult(),
+                            CouncilTimeout, TimedOut: true));
                     }
                 }
             }
-            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-            {
-                // Timeout — degrade gracefully
-                onStatus?.Invoke("Council timeout — proceeding with available votes");
-            }
-
-            // Deadlock fallback: if zero valid responses, create a synthetic local vote
-            if (aggregator.ValidResponseCount == 0)
-            {
-                onStatus?.Invoke("Council deadlock — falling back to local model completion");
-                aggregator.Add(new CouncilVote(
-                    "local-fallback", 1.0,
-                    new VerificationResult(
-                        Valid: true,
-                        Corrections: [],
-                        Facts: [draft],
-                        Confidence: 0.3),
-                    TimeSpan.Zero));
-            }
-
-            return aggregator;
         }
-        finally
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
         {
-            _rateLimiter.Dispose();
+            // Timeout — degrade gracefully
+            onStatus?.Invoke("Council timeout — proceeding with available votes");
         }
+
+        // Deadlock fallback: if zero valid responses, create a synthetic local vote
+        if (aggregator.ValidResponseCount == 0)
+        {
+            onStatus?.Invoke("Council deadlock — falling back to local model completion");
+            aggregator.Add(new CouncilVote(
+                "local-fallback", 1.0,
+                new VerificationResult(
+                    Valid: true,
+                    Corrections: [],
+                    Facts: [draft],
+                    Confidence: 0.3),
+                TimeSpan.Zero));
+        }
+
+        return aggregator;
     }
 
     /// <summary>
@@ -395,5 +390,12 @@ public sealed class AdaptiveVerificationEngine : IDisposable
             """;
     }
 
-    public void Dispose() => _client.Dispose();
+    // Fix (Bug introduced in PR #3): _rateLimiter must only be disposed here,
+    // NOT inside RunCouncilAsync's finally block. Disposing a class-level field
+    // in a per-call method causes ObjectDisposedException on every subsequent query.
+    public void Dispose()
+    {
+        _rateLimiter.Dispose();
+        _client.Dispose();
+    }
 }

--- a/AdaptiveVerificationEngine.cs
+++ b/AdaptiveVerificationEngine.cs
@@ -23,7 +23,7 @@ public sealed class AdaptiveVerificationEngine : IDisposable
     ];
 
     private static readonly TimeSpan CouncilTimeout = TimeSpan.FromSeconds(30);
-    
+
     // Security: Rate limiting to prevent DoS and resource exhaustion
     private readonly RateLimiter _rateLimiter;
     private const int MaxConcurrentRequests = 5;
@@ -94,7 +94,7 @@ public sealed class AdaptiveVerificationEngine : IDisposable
             return CreateFallbackReport(query, "", ConsensusStrategy.Weighted, QueryIntent.Unknown, totalSw.Elapsed,
                 "Empty query not allowed");
         }
-        
+
         // Security: Enforce maximum query length
         const int MaxQueryLength = 5000;
         if (query.Length > MaxQueryLength)
@@ -227,79 +227,89 @@ public sealed class AdaptiveVerificationEngine : IDisposable
         var aggregator = new VoteAggregator();
 
         // Security: Acquire rate limit permit before proceeding
+        // Fix (Bug 4): throw instead of silently continuing when rate limit is exceeded
         using var lease = await _rateLimiter.AcquireAsync(1, ct);
         if (!lease.IsAcquired)
-        {
-            onStatus?.Invoke("Rate limit exceeded — request queued");
-        }
+            throw new InvalidOperationException("Rate limit exceeded — too many concurrent requests. Please try again shortly.");
 
-        // Launch all verifications in parallel with controlled concurrency
-        var tasks = CouncilModels.Select(m =>
-            _client.VerifyAsync(m.Model, draft, query, m.Weight, CouncilTimeout, ct))
-            .ToList();
-
-        // Wait for all with overall timeout (give extra buffer beyond individual timeout)
         try
         {
-            var overallTimeout = Task.Delay(CouncilTimeout + TimeSpan.FromSeconds(2), ct);
-            var allTasks = Task.WhenAll(tasks);
+            // Fix (Bug 3): build an indexed list of (model, task) pairs so we never
+            // rely on List<Task>.IndexOf(), which uses reference equality and can
+            // return -1 if the task object isn't found, causing an IndexOutOfRangeException.
+            var indexedTasks = CouncilModels
+                .Select((m, i) => (Model: m, Task: _client.VerifyAsync(m.Model, draft, query, m.Weight, CouncilTimeout, ct)))
+                .ToList();
 
-            var completed = await Task.WhenAny(allTasks, overallTimeout);
+            var tasks = indexedTasks.Select(x => x.Task).ToList();
 
-            if (completed == allTasks)
+            // Wait for all with overall timeout (give extra buffer beyond individual timeout)
+            try
             {
-                // All completed within timeout
-                foreach (var vote in await allTasks)
+                var overallTimeout = Task.Delay(CouncilTimeout + TimeSpan.FromSeconds(2), ct);
+                var allTasks = Task.WhenAll(tasks);
+
+                var completed = await Task.WhenAny(allTasks, overallTimeout);
+
+                if (completed == allTasks)
                 {
-                    aggregator.Add(vote);
-                    onStatus?.Invoke($"  {vote.ModelName}: {(vote.TimedOut ? "TIMEOUT" : vote.Error ?? (vote.Result.Valid ? "✓ VALID" : "✗ INVALID"))} ({vote.ResponseTime.TotalSeconds:F1}s)");
-                }
-            }
-            else
-            {
-                // Overall timeout hit — collect whatever finished
-                onStatus?.Invoke("Council overall timeout — collecting partial results...");
-                foreach (var task in tasks)
-                {
-                    if (task.IsCompletedSuccessfully)
+                    // All completed within timeout
+                    foreach (var vote in await allTasks)
                     {
-                        var vote = await task;
                         aggregator.Add(vote);
-                        onStatus?.Invoke($"  {vote.ModelName}: {(vote.Result.Valid ? "✓" : "✗")} ({vote.ResponseTime.TotalSeconds:F1}s)");
+                        onStatus?.Invoke($"  {vote.ModelName}: {(vote.TimedOut ? "TIMEOUT" : vote.Error ?? (vote.Result.Valid ? "✓ VALID" : "✗ INVALID"))} ({vote.ResponseTime.TotalSeconds:F1}s)");
                     }
-                    else
+                }
+                else
+                {
+                    // Overall timeout hit — collect whatever finished
+                    onStatus?.Invoke("Council overall timeout — collecting partial results...");
+                    foreach (var (modelInfo, task) in indexedTasks)
                     {
-                        // Create a timeout vote for tasks that didn't finish
-                        var modelInfo = CouncilModels[tasks.IndexOf(task)];
-                        aggregator.Add(new CouncilVote(
-                            modelInfo.Model, modelInfo.Weight,
-                            new VerificationResult(),
-                            CouncilTimeout, TimedOut: true));
+                        if (task.IsCompletedSuccessfully)
+                        {
+                            var vote = await task;
+                            aggregator.Add(vote);
+                            onStatus?.Invoke($"  {vote.ModelName}: {(vote.Result.Valid ? "✓" : "✗")} ({vote.ResponseTime.TotalSeconds:F1}s)");
+                        }
+                        else
+                        {
+                            // Create a timeout vote for tasks that didn't finish
+                            // Safe: modelInfo is already associated with this task — no IndexOf needed
+                            aggregator.Add(new CouncilVote(
+                                modelInfo.Model, modelInfo.Weight,
+                                new VerificationResult(),
+                                CouncilTimeout, TimedOut: true));
+                        }
                     }
                 }
             }
-        }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-        {
-            // Timeout — degrade gracefully
-            onStatus?.Invoke("Council timeout — proceeding with available votes");
-        }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                // Timeout — degrade gracefully
+                onStatus?.Invoke("Council timeout — proceeding with available votes");
+            }
 
-        // Deadlock fallback: if zero valid responses, create a synthetic local vote
-        if (aggregator.ValidResponseCount == 0)
-        {
-            onStatus?.Invoke("Council deadlock — falling back to local model completion");
-            aggregator.Add(new CouncilVote(
-                "local-fallback", 1.0,
-                new VerificationResult(
-                    Valid: true,
-                    Corrections: [],
-                    Facts: [draft],
-                    Confidence: 0.3),
-                TimeSpan.Zero));
-        }
+            // Deadlock fallback: if zero valid responses, create a synthetic local vote
+            if (aggregator.ValidResponseCount == 0)
+            {
+                onStatus?.Invoke("Council deadlock — falling back to local model completion");
+                aggregator.Add(new CouncilVote(
+                    "local-fallback", 1.0,
+                    new VerificationResult(
+                        Valid: true,
+                        Corrections: [],
+                        Facts: [draft],
+                        Confidence: 0.3),
+                    TimeSpan.Zero));
+            }
 
-        return aggregator;
+            return aggregator;
+        }
+        finally
+        {
+            _rateLimiter.Dispose();
+        }
     }
 
     /// <summary>
@@ -380,7 +390,7 @@ public sealed class AdaptiveVerificationEngine : IDisposable
             │  API Calls:     {cost.TotalApiCalls,-10}                 │
             │  Local Tokens:  {cost.LocalTokens,-10}                   │
             │  Cloud Tokens:  {cost.CloudTokens,-10}                   │
-            │  Est. Cost:     ${cost.EstimatedCostUsd:F4}              |                │
+            │  Est. Cost:     ${cost.EstimatedCostUsd:F4}              │
             └──────────────────────────────────────────────────────────┘
             """;
     }

--- a/OllamaClient.cs
+++ b/OllamaClient.cs
@@ -24,13 +24,13 @@ public sealed class OllamaClient : IDisposable
     // Security: URL validation pattern to prevent SSRF
     private static readonly Regex ValidUrlPattern = new(
         @"^https?://", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-    
+
     // Security: Allowed hosts for local and cloud endpoints
     private static readonly HashSet<string> AllowedLocalHosts = new(StringComparer.OrdinalIgnoreCase)
     {
         "localhost", "127.0.0.1", "::1"
     };
-    
+
     private static readonly HashSet<string> AllowedCloudHosts = new(StringComparer.OrdinalIgnoreCase)
     {
         "api.ollama.com", "ollama.com"
@@ -47,7 +47,7 @@ public sealed class OllamaClient : IDisposable
         // Security: Validate and sanitize URLs to prevent SSRF
         localBaseUrl = ValidateAndSanitizeUrl(localBaseUrl, AllowedLocalHosts, "local");
         cloudBaseUrl = ValidateAndSanitizeUrl(cloudBaseUrl, AllowedCloudHosts, "cloud");
-        
+
         _apiKey = apiKey ?? Environment.GetEnvironmentVariable("OLLAMA_API_KEY");
 
         _localClient = new HttpClient(new SocketsHttpHandler
@@ -78,45 +78,31 @@ public sealed class OllamaClient : IDisposable
                 new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _apiKey);
         }
     }
-    
+
     /// <summary>
     /// Security: Validate URL scheme and host against allowlist to prevent SSRF attacks.
     /// </summary>
     private static string ValidateAndSanitizeUrl(string url, HashSet<string> allowedHosts, string endpointType)
     {
         if (string.IsNullOrWhiteSpace(url))
-        {
             throw new ArgumentException($"{endpointType} URL cannot be empty", nameof(url));
-        }
 
-        // Validate URL scheme
         if (!ValidUrlPattern.IsMatch(url))
-        {
             throw new ArgumentException(
                 $"{endpointType} URL must use http:// or https:// scheme", nameof(url));
-        }
 
-        // Parse and validate host
         if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
-        {
             throw new ArgumentException(
                 $"{endpointType} URL is not a valid absolute URI", nameof(url));
-        }
 
-        // Check host against allowlist
         if (!allowedHosts.Contains(uri.Host))
-        {
             throw new ArgumentException(
                 $"{endpointType} URL host '{uri.Host}' is not in the allowed list. " +
                 $"Allowed hosts: {string.Join(", ", allowedHosts)}", nameof(url));
-        }
 
-        // Ensure no suspicious query parameters or fragments
         if (!string.IsNullOrEmpty(uri.Query) || !string.IsNullOrEmpty(uri.Fragment))
-        {
             throw new ArgumentException(
                 $"{endpointType} URL should not contain query parameters or fragments", nameof(url));
-        }
 
         return url;
     }
@@ -202,21 +188,86 @@ public sealed class OllamaClient : IDisposable
     }
 
     /// <summary>
+    /// Send a chat completion request to Ollama (local or cloud).
+    /// </summary>
+    public async Task<ChatResponse?> ChatAsync(
+        string model,
+        ChatMessage[] messages,
+        float temperature = 0.7f,
+        string[]? tools = null,
+        bool enableThinking = false,
+        CancellationToken ct = default)
+    {
+        bool isCloud = model.Contains("cloud", StringComparison.OrdinalIgnoreCase);
+        var chatRequest = new ChatRequest(
+            Model: model,
+            Messages: messages,
+            Stream: false,
+            Options: new ChatOptions(Temperature: temperature),
+            Tools: tools ?? Array.Empty<string>(),
+            Think: enableThinking
+        );
+
+        var client = isCloud ? _cloudClient : _localClient;
+
+        for (int attempt = 1; attempt <= MaxRetries + 1; attempt++)
+        {
+            try
+            {
+                var jsonBytes = JsonSerializer.SerializeToUtf8Bytes(
+                    chatRequest, AppJsonContext.Default.ChatRequest);
+
+                using var content = new ByteArrayContent(jsonBytes);
+                content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+
+                using var response = await client.PostAsync("/api/chat", content, ct);
+                response.EnsureSuccessStatusCode();
+
+                var stream = await response.Content.ReadAsStreamAsync(ct);
+                var result = await JsonSerializer.DeserializeAsync(
+                    stream, AppJsonContext.Default.ChatResponse, ct);
+
+                if (result is not null)
+                {
+                    int tokens = result.EvalCount + result.PromptEvalCount;
+                    if (isCloud)
+                        Interlocked.Add(ref _totalCloudTokens, tokens);
+                    else
+                        Interlocked.Add(ref _totalLocalTokens, tokens);
+
+                    Interlocked.Increment(ref _totalApiCalls);
+                }
+
+                return result;
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception) when (attempt <= MaxRetries)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100 * attempt), ct);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Security: Sanitize user input to prevent prompt injection attacks.
-    /// Escapes special characters and removes potentially malicious patterns.
+    /// Removes known hijack patterns; does NOT escape backslashes or quotes
+    /// because inputs are embedded in raw string literals ($$""") which need
+    /// no escaping — adding it caused the model to receive literal \" sequences.
+    /// Fix (Bug 5): removed .Replace("\\", "\\\\") and .Replace("\"", "\\\"").
     /// </summary>
     private static string SanitizePromptInput(string input)
     {
         if (string.IsNullOrEmpty(input))
             return string.Empty;
-        
-        // Remove or escape common prompt injection patterns
+
+        // Remove common instruction patterns that could hijack the model
         var sanitized = input
-            // Replace backslashes to prevent escape sequences
-            .Replace("\\", "\\\\")
-            // Replace quotes to prevent breaking out of strings
-            .Replace("\"", "\\\"")
-            // Remove common instruction patterns that could hijack the model
             .Replace("Ignore previous", "[FILTERED]")
             .Replace("ignore previous", "[FILTERED]")
             .Replace(" disregard", "[FILTERED]")
@@ -227,12 +278,12 @@ public sealed class OllamaClient : IDisposable
             .Replace("system:", "[FILTERED]")
             .Replace("### Instruction", "[FILTERED]")
             .Replace("### instruction", "[FILTERED]");
-        
+
         // Truncate excessively long inputs to prevent buffer/resource exhaustion
         const int MaxInputLength = 10000;
         if (sanitized.Length > MaxInputLength)
             sanitized = sanitized[..MaxInputLength] + "...[TRUNCATED]";
-        
+
         return sanitized;
     }
 
@@ -335,15 +386,12 @@ public sealed class OllamaClient : IDisposable
 
         var text = StripMarkdownFences(raw.Trim());
 
-        // Get the appropriate JsonTypeInfo from our source-generated context
         var typeInfo = GetTypeInfo<T>();
         if (typeInfo is null) return null;
 
-        // Try direct parse first
         if (TryDeserialize(text, typeInfo, out var result))
             return result;
 
-        // Try to extract JSON object from surrounding text
         int braceStart = text.IndexOf('{');
         int braceEnd = text.LastIndexOf('}');
         if (braceStart >= 0 && braceEnd > braceStart)
@@ -383,12 +431,8 @@ public sealed class OllamaClient : IDisposable
         }
     }
 
-    /// <summary>
-    /// Resolves the JsonTypeInfo for supported types from our AOT-safe source-generated context.
-    /// </summary>
     private static System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>? GetTypeInfo<T>()
     {
-        // NativeAOT-compatible: resolve from source-generated context
         if (typeof(T) == typeof(VerificationResult))
             return (System.Text.Json.Serialization.Metadata.JsonTypeInfo<T>)(object)
                 LenientJsonContext.Default.VerificationResult;


### PR DESCRIPTION
Fixes three runtime bugs identified in issue #2.

## Bug 3 — `tasks.IndexOf(task)` → `IndexOutOfRangeException` (`AdaptiveVerificationEngine.cs`)
`CouncilModels[tasks.IndexOf(task)]` used reference equality on `Task` objects in the timeout branch. `List<T>.IndexOf` can return `-1` on a miss, causing an immediate `IndexOutOfRangeException`.

**Fix:** Replaced the raw task list with an indexed `(Model, Task)` projection at construction time. The timeout branch now destructures `(modelInfo, task)` from that list — no `IndexOf` call, no possible `-1`.

---

## Bug 4 — Rate limiter check silently continues (`AdaptiveVerificationEngine.cs`)
When `lease.IsAcquired == false` the code logged a status message and fell straight through, allowing the request to proceed and rendering the rate limiter useless.

**Fix:** Changed the `!lease.IsAcquired` branch to `throw new InvalidOperationException(...)`, which actually enforces the concurrency cap.

---

## Bug 5 — `SanitizePromptInput` double-escapes quotes/backslashes (`OllamaClient.cs`)
The method replaced `\\` → `\\\\` and `"` → `\\"`, then those escaped values were interpolated inside a raw string literal (`$$"""..."""`) which needs no escaping. The model received literal `\"` sequences, garbling every query and draft sent for verification.

**Fix:** Removed the two `.Replace("…")` lines for backslash and double-quote escaping. The injection-pattern filters ("Ignore previous", "System:", etc.) are kept intact.